### PR TITLE
Changing exporter to struct

### DIFF
--- a/pkg/exporter/process_test.go
+++ b/pkg/exporter/process_test.go
@@ -85,12 +85,12 @@ func TestExportingProcess_SendingTemplateRecordToLocalUDPServer(t *testing.T) {
 	if err != nil {
 		t.Errorf("Did not find the element with name sourceIPv4Address")
 	}
-	tempRec.AddInfoElement(&element, nil)
+	tempRec.AddInfoElement(element, nil)
 	element, err = reg.GetInfoElement("destinationIPv4Address")
 	if err != nil {
 		t.Errorf("Did not find the element with name destinationIPv4Address")
 	}
-	tempRec.AddInfoElement(&element, nil)
+	tempRec.AddInfoElement(element, nil)
 	tempRecBuff := tempRec.GetBuffer()
 	tempRecBytes := tempRecBuff.Bytes()
 
@@ -215,13 +215,13 @@ func TestExportingProcess_SendingDataRecordToLocalUDPServer(t *testing.T) {
 	if err != nil {
 		t.Errorf("Did not find the element with name sourceIPv4Address")
 	}
-	dataRec.AddInfoElement(&element, net.ParseIP("1.2.3.4"))
+	dataRec.AddInfoElement(element, net.ParseIP("1.2.3.4"))
 
 	element, err = reg.GetInfoElement("destinationIPv4Address")
 	if err != nil {
 		t.Errorf("Did not find the element with name destinationIPv4Address")
 	}
-	dataRec.AddInfoElement(&element, net.ParseIP("5.6.7.8"))
+	dataRec.AddInfoElement(element, net.ParseIP("5.6.7.8"))
 	dataRecBuff := dataRec.GetBuffer()
 	dataRecBytes := dataRecBuff.Bytes()
 


### PR DESCRIPTION
This way it can be better utilized by user as he could create mocks for
unit tests instead of testing the library from his code.

Took care of bug in udp server process_test too as I was testing. Your PR has conflicting change.

Library testing should be separate and done by its own.